### PR TITLE
Fixed `.clone.meta` file deserialization bug

### DIFF
--- a/crates/tweak/src/metadata.rs
+++ b/crates/tweak/src/metadata.rs
@@ -154,6 +154,7 @@ impl ClonedProject {
 /// cloned contract. This struct is the twin of the `CloneMetadata` struct in the `clone` command of
 /// `forge` crate.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloneMetadata {
     /// The path to the source file that contains the contract declaration.
     /// The path is relative to the root directory of the project.


### PR DESCRIPTION
Got error when running `cast run --tweak`

`cast run --tweak UniswapV3 0x2cc0341cbd7b7ce5d72a488079eace1773b583d951a9b6d371c74c6fd4bf72d4`

<pre>
Error:
failed to load tweak project from path: "~/pocs/UniswapV3"

Context:
- missing field `target_contract` at line 1 column 7266
</pre>


## Solution

`forge clone` used camelCase to store the fields in `.clone.meta` 

https://github.com/MEDGA-eth/foundry/blob/3f87f29083febd31d6d22dec3b0b71949655cbf7/crates/forge/bin/cmd/clone.rs#L30-L50


So `cast run --tweak` should also use camelCase to read the `.clone.meta` file accordingly

https://github.com/0xstonegm/foundry/blob/6add3ce1a241cb11ac1e6d27707df6f8db4ae901/crates/tweak/src/metadata.rs#L157

```diff
#[derive(Debug, Clone, Default, serde::Deserialize)]
+ #[serde(rename_all = "camelCase")]
pub struct CloneMetadata {
    /// The path to the source file that contains the contract declaration.
    /// The path is relative to the root directory of the project.
```